### PR TITLE
cannot store nil values in boolean fields

### DIFF
--- a/lib/serialized_attributes/types.rb
+++ b/lib/serialized_attributes/types.rb
@@ -22,7 +22,10 @@ module SerializedAttributes
 
   class Boolean < AttributeType
     def parse(input)  input && input.respond_to?(:to_i) ? (input.to_i > 0) : input end
-    def encode(input) input ? 1 : 0  end
+    def encode(input)
+      return nil if input.nil?
+      input ? 1 : 0
+    end
   end
 
   class String < AttributeType

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -306,7 +306,7 @@ formatters.each do |fmt|
 
     test "defines #active_before_type_cast method on the model" do
       assert @record.respond_to?(:active_before_type_cast)
-      assert_equal "0", @record.active_before_type_cast
+      assert_equal "", @record.active_before_type_cast
     end
 
     attributes[:string].each do |attr|

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+require File.dirname(__FILE__) + '/test_helper'
+
+class SerializedAttributesTypesTest < ActiveSupport::TestCase
+
+  test "boolean type encodes nil properly" do
+    type = SerializedAttributes::Boolean.new
+
+    assert_equal nil, type.encode(nil)
+  end
+
+end


### PR DESCRIPTION
If an attribute is boolean, it is impossible to persist a nil value to the field as it is always converted to false.
