### PR TITLE
use duplicable? so symbols are not duped

### DIFF
--- a/lib/serialized_attributes.rb
+++ b/lib/serialized_attributes.rb
@@ -34,6 +34,10 @@
 module SerializedAttributes
   require 'serialized_attributes/types'
 
+  if defined?(Rails) && Rails::VERSION::MAJOR <= 2 && Rails::VERSION::MINOR <= 2
+    require 'serialized_attributes/duplicable'
+  end
+
   module Format
     autoload :ActiveSupportJson, 'serialized_attributes/format/active_support_json'
   end

--- a/lib/serialized_attributes.rb
+++ b/lib/serialized_attributes.rb
@@ -34,7 +34,7 @@
 module SerializedAttributes
   require 'serialized_attributes/types'
 
-  if defined?(Rails) && Rails::VERSION::MAJOR <= 2 && Rails::VERSION::MINOR <= 2
+  if nil.respond_to?(:duplicable?)
     require 'serialized_attributes/duplicable'
   end
 

--- a/lib/serialized_attributes/duplicable.rb
+++ b/lib/serialized_attributes/duplicable.rb
@@ -1,0 +1,65 @@
+# Most objects are cloneable, but not all. For example you can't dup +nil+:
+#
+#   nil.dup # => TypeError: can't dup NilClass
+#
+# Classes may signal their instances are not duplicable removing +dup+/+clone+
+# or raising exceptions from them. So, to dup an arbitrary object you normally
+# use an optimistic approach and are ready to catch an exception, say:
+#
+#   arbitrary_object.dup rescue object
+#
+# Rails dups objects in a few critical spots where they are not that arbitrary.
+# That rescue is very expensive (like 40 times slower than a predicate), and it
+# is often triggered.
+#
+# That's why we hardcode the following cases and check duplicable? instead of
+# using that rescue idiom.
+class Object
+  # Can you safely .dup this object?
+  # False for nil, false, true, symbols, numbers, class and module objects; true otherwise.
+  def duplicable?
+    true
+  end
+end
+
+class NilClass #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class FalseClass #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class TrueClass #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class Symbol #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class Numeric #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class Class #:nodoc:
+  def duplicable?
+    false
+  end
+end
+
+class Module #:nodoc:
+  def duplicable?
+    false
+  end
+end

--- a/lib/serialized_attributes/types.rb
+++ b/lib/serialized_attributes/types.rb
@@ -11,7 +11,7 @@ module SerializedAttributes
     end
 
     def default
-      @default && @default.respond_to?(:dup) ? @default.dup : @default
+      @default && @default.duplicable? ? @default.dup : @default
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,6 +76,7 @@ class SerializedRecordWithDefaults < ActiveRecord::Base
     boolean :active,       :default => true
     array   :names,        :default => %w(a b c)
     hash    :extras,       :default => {:a => 1}
+    string  :symbol,       :default => :foo
   end
 
   before_save { |r| false } # cancel the save


### PR DESCRIPTION
For some reason Symbol responds to dup, but errors when it is called.  Instead we can take advantage of Object#duplicable? from Rails which handles this correctly.
