### PR TITLE
treat strings that represent booleans as booleans

### DIFF
--- a/lib/serialized_attributes/types.rb
+++ b/lib/serialized_attributes/types.rb
@@ -29,7 +29,10 @@ module SerializedAttributes
     attr_reader :default
     def parse(input)  input && input.respond_to?(:to_i) ? (input.to_i > 0) : input end
     def encode(input)
-      return nil if input.nil?
+      return nil if input.blank?
+      return 1 if input == 'true'
+      return 0 if input == 'false'
+
       input ? 1 : 0
     end
   end

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -9,4 +9,17 @@ class SerializedAttributesTypesTest < ActiveSupport::TestCase
     assert_equal nil, type.encode(nil)
   end
 
+  test "boolean type encodes blank string properly" do
+    type = SerializedAttributes::Boolean.new
+
+    assert_equal nil, type.encode("")
+  end
+
+  test "boolean type handles strings that look like booleans" do
+    type = SerializedAttributes::Boolean.new
+
+    assert_equal 0, type.encode("false")
+    assert_equal 1,  type.encode("true")
+  end
+
 end


### PR DESCRIPTION
This patch will treat strings that look like boolean values as booleans.  I'm not sure if this entirely makes sense, I guess I could wire my forms up to send 0 or 1 instead of false or true.
