### PR TITLE
fixed Schema read_attribute when using custom data_field

### DIFF
--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -96,7 +96,7 @@ module SerializableAttributes
       @model.send(:define_method, :read_attribute) do |attribute_name|
         schema = self.class.send("#{data_field}_schema")
         if schema.include?(attribute_name)
-          data[attribute_name.to_s]
+          send(data_field)[attribute_name.to_s]
         else
           super(attribute_name)
         end

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -291,6 +291,27 @@ formatters.each do |fmt|
     end
   end
 
+  Object.const_set("SerializedAttributeWithSerializedPrefsDataTestWith#{fmt.name.demodulize}", Class.new(ActiveSupport::TestCase)).class_eval do
+    class << self
+      attr_accessor :format, :current_time, :raw_hash, :raw_prefs
+    end
+    self.format       = fmt
+    self.current_time = Time.now.utc.midnight
+    self.raw_hash     = {:title => 'abc'}
+    self.raw_prefs    = format.encode(raw_hash)
+
+    def setup
+      SerializedPrefsRecord.prefs_schema.formatter = self.class.format
+      @record  = SerializedPrefsRecord.new
+      @record.raw_prefs  = self.class.raw_prefs
+    end
+
+    test "#read_attribute reads serialized fields" do
+      @record.body = 'a'
+      assert_equal 'a', @record.read_attribute(:body)
+    end
+  end
+
   Object.const_set("SerializedAttributeTest#{fmt.name.demodulize}", Class.new(ActiveSupport::TestCase)).class_eval do
     class << self
       attr_accessor :format

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,3 +105,18 @@ class SerializedRecordWithDefaults < ActiveRecord::Base
   def add_to_transaction
   end
 end
+
+class SerializedPrefsRecord < ActiveRecord::Base
+  extend SerializableMethods
+
+  attr_accessor :raw_prefs
+
+  serialize_attributes :prefs do
+    string  :title, :body
+  end
+
+  before_save { |r| false } # cancel the save
+
+  def add_to_transaction
+  end
+end


### PR DESCRIPTION
I was trying to use a custom data field (e.g. serialize_attributes :goals, :blob => :raw_goals) when I encountered a bug in the read_attribute method. It was assuming the field name was data and was raising NameError: undefined local variable or method. I fixed it and added a test for it.
