### PR TITLE
Paper Trail compatibility

### DIFF
--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -156,7 +156,7 @@ module SerializableAttributes
       end
       
       @model.send(:define_method, :dup) do
-        duplicate = super
+        duplicate = super()
         duplicate.send("#{blob_field}=", self.send(blob_field).try(:dup))
         duplicate.reset_serialized_data
         duplicate

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -157,9 +157,9 @@ module SerializableAttributes
       
       @model.send(:define_method, :dup) do
         duplicate = super()
-        if raw_data = self.send(blob_field)
-          duplicate.send("#{blob_field}=", raw_data.dup)
-        end
+        raw_data = self.send(blob_field)
+        raw_data &&= raw_data.dup
+        duplicate.send("#{blob_field}=", raw_data)
         duplicate.reset_serialized_data
         duplicate
       end

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -157,7 +157,9 @@ module SerializableAttributes
       
       @model.send(:define_method, :dup) do
         duplicate = super()
-        duplicate.send("#{blob_field}=", self.send(blob_field).try(:dup))
+        if raw_data = self.send(blob_field)
+          duplicate.send("#{blob_field}=", raw_data.dup)
+        end
         duplicate.reset_serialized_data
         duplicate
       end

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -146,6 +146,13 @@ module SerializableAttributes
         !send(changed_ivar).empty?
       end
 
+      @model.send(:define_method, :dup) do
+        duplicate = super
+        duplicate.send("#{blob_field}=", self.send(blob_field).dup)
+        duplicate.reset_serialized_data
+        duplicate
+      end
+
       @model.before_save do |r|
         schema = r.class.send("#{data_field}_schema")
         r.send("#{blob_field}=", schema.encode(r.send(data_field)))

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -101,6 +101,15 @@ module SerializableAttributes
           super(attribute_name)
         end
       end
+      
+      @model.send(:define_method, :write_attribute) do |attr_name, value|
+        schema = self.class.send("#{data_field}_schema")
+        if schema.include?(attr_name)
+          self.write_serialized_field(attr_name, value)
+        else
+          super(attr_name, value)
+        end
+      end
 
       if defined?(ActiveRecord::VERSION) && ActiveRecord::VERSION::STRING >= '3.1'
         @model.send(:define_method, :attributes) do
@@ -145,7 +154,7 @@ module SerializableAttributes
       @model.send(:define_method, "#{changed_ivar}?") do
         !send(changed_ivar).empty?
       end
-
+      
       @model.send(:define_method, :dup) do
         duplicate = super
         duplicate.send("#{blob_field}=", self.send(blob_field).dup)

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -96,7 +96,7 @@ module SerializableAttributes
       @model.send(:define_method, :read_attribute) do |attribute_name|
         schema = self.class.send("#{data_field}_schema")
         if schema.include?(attribute_name)
-          data[attribute_name.to_s]
+          send(data_field)[attribute_name.to_s]
         else
           super(attribute_name)
         end

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -128,6 +128,7 @@ module SerializableAttributes
         changed_fields = send(changed_ivar)
         instance_variable_get("@#{changed_ivar}")[name_str] = raw_data[name_str] unless changed_fields.include?(name_str)
         parsed_value = type ? type.parse(value) : value
+        self.send(:attribute_will_change!, name_str)
         if parsed_value.nil?
           raw_data.delete(name_str)
         else

--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -157,7 +157,7 @@ module SerializableAttributes
       
       @model.send(:define_method, :dup) do
         duplicate = super
-        duplicate.send("#{blob_field}=", self.send(blob_field).dup)
+        duplicate.send("#{blob_field}=", self.send(blob_field).try(:dup))
         duplicate.reset_serialized_data
         duplicate
       end

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -21,6 +21,7 @@ formatters.each do |fmt|
       @changed.raw_data = self.class.raw_data
       @changed.title    = 'def'
       @changed.age      = 6
+      @changed[:active] = false
     end
 
     test "schema lists attribute names" do
@@ -94,6 +95,12 @@ formatters.each do |fmt|
     test "#read_attribute reads serialized fields" do
       @record.body = 'a'
       assert_equal 'a', @record.read_attribute(:body)
+    end
+    
+    test "#write_attribute writes serialized fields" do
+      # Note: #[] is an alias for #write_attribute, but #write_attribute is deprecated
+      @record[:body] = 'a'
+      assert_equal 'a', @record.body
     end
 
     test "#attributes contains serialized fields" do
@@ -277,7 +284,7 @@ formatters.each do |fmt|
 
     test "knows updated record is changed" do
       assert @changed.data_changed?
-      assert_equal %w(age title), @changed.data_changed.sort
+      assert_equal %w(active age title), @changed.data_changed.sort
     end
 
     test "tracks if field has changed" do
@@ -295,7 +302,7 @@ formatters.each do |fmt|
       assert_empty @record.changes
       
       assert @changed.changed?
-      assert_equal @changed.changes, {'title' => ['abc', 'def'], 'age' => [5, 6]}
+      assert_equal @changed.changes, {'title' => ['abc', 'def'], 'age' => [5, 6], 'active' => [true, false]}
     end
   end
 

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -297,12 +297,28 @@ formatters.each do |fmt|
       assert_equal %w(abc def), @changed.title_change
     end
     
-    test 'tracks dirty on the model' do
+    test "tracks dirty on the model" do
       assert !@record.changed?
       assert_empty @record.changes
       
       assert @changed.changed?
       assert_equal @changed.changes, {'title' => ['abc', 'def'], 'age' => [5, 6], 'active' => [true, false]}
+    end
+    
+    test "changes a dup without modifying the original" do
+      @duped = @record.dup
+      assert !(@record.raw_data.equal? @duped.raw_data)
+      assert !(@record.data.equal? @duped.data)
+      
+      @duped.title = 'ghi'
+      assert_equal 'ghi', @duped.title
+      assert_equal 'abc', @record.title
+    end
+    
+    test "creates a dup when blob field is nil" do
+      @record = SerializedRecord.new
+      @duped = @record.dup
+      assert_nil @duped.raw_data
     end
   end
 

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -289,6 +289,14 @@ formatters.each do |fmt|
       assert_nil @record.title_change
       assert_equal %w(abc def), @changed.title_change
     end
+    
+    test 'tracks dirty on the model' do
+      assert !@record.changed?
+      assert_empty @record.changes
+      
+      assert @changed.changed?
+      assert_equal @changed.changes, {'title' => ['abc', 'def'], 'age' => [5, 6]}
+    end
   end
 
   Object.const_set("SerializedAttributeTest#{fmt.name.demodulize}", Class.new(ActiveSupport::TestCase)).class_eval do

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -299,7 +299,7 @@ formatters.each do |fmt|
     
     test "tracks dirty on the model" do
       assert !@record.changed?
-      assert_empty @record.changes
+      assert @record.changes.empty?
       
       assert @changed.changed?
       assert_equal @changed.changes, {'title' => ['abc', 'def'], 'age' => [5, 6], 'active' => [true, false]}


### PR DESCRIPTION
Hi,

I've been trying to get serialized_attributes and [Paper Trail](https://github.com/airblade/paper_trail) to work happily together. It turns out that Paper Trail depends on quite a few ActiveRecord features that didn't happen to be implemented for serialized attributes.

Instead of creating a bunch of different pull requests, I decided to lump everything together and just summarize what got changed.
- Fixed a bug where a reference to the 'data' field was hardcoded as `data` instead of using `send(data_field)`.
- Added support for dirty attributes by calling `attribute_will_change!`.
- Overrode `dup` so it copies over a dup of the serialized data. Previously, the dup'ed object would keep a reference to the same serialized data as the original object. This fix is necessary because Paper Trail creates a version by duping the object, and then setting all attributes back to their previous values. So, modifying the dup was also modifying the serialized attributes on the original object.
- Added support for `[]=` AKA `write_attribute` to modify serialized data.
