### PR TITLE
Don't write blob column if no attributes changed

### DIFF
--- a/lib/serializable_attributes/schema.rb
+++ b/lib/serializable_attributes/schema.rb
@@ -130,7 +130,9 @@ module SerializableAttributes
 
       @model.before_save do |r|
         schema = r.class.send("#{data_field}_schema")
-        r.send("#{blob_field}=", schema.encode(r.send(data_field)))
+        if r.send(blob_field).nil? || !r.send(changed_ivar).empty?
+          r.send("#{blob_field}=", schema.encode(r.send(data_field)))
+        end
       end
     end
 

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -101,6 +101,7 @@ formatters.each do |fmt|
     test "ignores data with extra keys" do
       @record.raw_data = self.class.format.encode(self.class.raw_hash.merge(:foo => :bar))
       assert_not_nil @record.title     # no undefined foo= error
+      @record.title = "changed" # force a change / rewrite
       assert_equal false, @record.save # extra before_save cancels the operation
       assert_equal self.class.raw_hash.merge(:active => 1).stringify_keys.keys.sort, self.class.format.decode(@record.raw_data).keys.sort
     end


### PR DESCRIPTION
This stops the `raw_data` attribute from being flagged as changed any time a model is saved. Instead, only write the attribute if one of the serialized attributes changed. This prevents an `UPDATE` statement entirely when `#save` is called and no actual changes were made. It prevents the blob column from being included in the `UPDATE` when only non-serialized attributes are changed.
